### PR TITLE
Support form encoded parameters, required by Microsoft

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,9 @@ Service providers varying how they communicate at their authorization and token
 endpoints. The accepted HTTP methods and how the request's parameters delivered
 must be configured in the `services.yaml` file for both endpoints. Options for
 `*_http_method` are `POST` and `GET`. Options for `*_params_mode` are
-`query-string`, `request-body` or `both`. When `both` is configured `mailctl`
-uses the `request-body` method since it is considered safer.
+`query-string`, `request-body` (JSON encoded), `request-body-form`
+(x-www-form-encoded) or `both`. When `both` is configured `mailctl` uses the
+`request-body` method since it is considered safer.
 
 If you encounter difficulties during *authorization* or *renewal* try to use
 the `--debug` switch which causes `mailctl` to mirror print HTTP traffic to

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ endpoints. The accepted HTTP methods and how the request's parameters delivered
 must be configured in the `services.yaml` file for both endpoints. Options for
 `*_http_method` are `POST` and `GET`. Options for `*_params_mode` are
 `query-string`, `request-body` (JSON encoded), `request-body-form`
-(x-www-form-encoded) or `both`. When `both` is configured `mailctl` uses the
+(x-www-form-urlencoded) or `both`. When `both` is configured `mailctl` uses the
 `request-body` method since it is considered safer.
 
 If you encounter difficulties during *authorization* or *renewal* try to use

--- a/configs/services-template.yaml
+++ b/configs/services-template.yaml
@@ -15,8 +15,8 @@ microsoft:
   auth_http_method: GET
   auth_params_mode: query-string
   token_endpoint: https://login.microsoftonline.com/common/oauth2/v2.0/token
-  token_http_method: GET
-  token_params_mode: query-string
+  token_http_method: POST
+  token_params_mode: request-body-form
   redirect_uri: http://localhost:8080
   auth_scope: https://outlook.office365.com/IMAP.AccessAsUser.All https://outlook.office365.com/SMTP.Send offline_access
   client_id: XXXXXXXXXXXXXXXXXXXXXXX

--- a/lib/MailCtl/Environment.hs
+++ b/lib/MailCtl/Environment.hs
@@ -75,7 +75,7 @@ data SystemState = SystemState
   }
   deriving (Show, Generic, ToJSON)
 
-data ParamsMode = RequestBody | QueryString
+data ParamsMode = RequestBody | RequestBodyForm | QueryString
 data HTTPMethod = POST | GET
 
 data Service = Service

--- a/lib/MailCtl/Environment.hs
+++ b/lib/MailCtl/Environment.hs
@@ -186,8 +186,11 @@ getCrontab = do
               z = T.concat ys
           return $ Just $ T.unpack z
         else do
-          putStr e
-          return Nothing
+          if not (T.isInfixOf "no crontab for" (T.pack e))
+            then do
+              putStr e
+              return Nothing
+            else return Nothing
     else return Nothing
 
 isCronEnabled :: Environment -> IO Bool


### PR DESCRIPTION
I've made this change to allow me to authenticate against Microsoft 365 - basically it looks like MS require requests to the token endpoint to be POST requests, but with the parameters form encoded in the body rather than the JSON which is required for Google.

I haven't actually got this working end to end yet, but I have obtained an access token.

Hope it's useful!

Phil