### PR TITLE
Push login hint dropping logic into auth form

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,28 +78,23 @@ example:
 
     % mailctl authorize -h
 
-    Usage: mailctl authorize <service> <email> [--company]
+    Usage: mailctl authorize <service> <email> [--nohint]
 
       Authorize OAuth2 for service/email
 
     Available options:
       <service>                Service name
       <email>                  Email address
-      --company                Treat <email> as company/institution email address
+      --nohint                 Don't pass login hint
       -h,--help                Show this help text
 
 Shell completion for `bash`, `zsh` and `fish` shells are provided.
 
-### Authorization for Organizational/Institutional accounts
+### Authorization for Corporate/Organizational/Institutional accounts
 
-The authorization process of Organizational/Institutional accounts can
-slightly be different from of individual accounts.
-
-#### Google Organizational Account
-
-When you want to authorize such an account invoke `mailctl` like this:
-
-    mailctl authorize google <you@company.email> --company
+Corporation/Organization/Institution accounts might be treated differently by
+the service provider. In such cases, not passing a login hint might be useful --
+this is eg the case for Google organizational accounts.
 
 #### Microsoft Organizational Account
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -16,7 +16,7 @@ main = do
       Getpwd emailAddress -> getEmailPwd env (EmailAddress emailAddress)
       Oauth2 emailAddress -> getEmailAuth env (EmailAddress emailAddress)
       Renew emailAddress -> forceRenew env (EmailAddress emailAddress)
-      Authorize servName emailAddress company -> authorizeEmail env servName (EmailAddress emailAddress) company
+      Authorize servName emailAddress nohint -> authorizeEmail env servName (EmailAddress emailAddress) nohint
       Fetch emailAddresses ->
         case fdm_config $ config env of
           Just fdm_config_ -> fetch env fdm_config_ (EmailAddress <$> emailAddresses)

--- a/lib/MailCtl/CommandLine.hs
+++ b/lib/MailCtl/CommandLine.hs
@@ -103,10 +103,7 @@ authorizeOptions =
   Authorize
     <$> strArgument (metavar "<service>" <> help "Service name")
     <*> strArgument (metavar "<email>" <> help "Email address")
-    <*> switch
-      ( long "company"
-          <> help "Treat <email> as company/institution email address"
-      )
+    <*> switch (long "nohint" <> help "Don't pass login hint")
 
 listEmails :: Mod CommandFields Command
 listEmails = command "list" (info (pure ListEmails) (progDesc "List all accounts in fdm's config"))


### PR DESCRIPTION
In particular, this restricts the use of dummy emails _only_ to dropping
login hints.
Renamed the commandline flag to correspond to this semantic change.
Closes: #22
