### PR TITLE
build(cabal): pin pdobsan/githash (fork) source-repository-package to d006ec1

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -4,3 +4,4 @@ packages:
 source-repository-package
     type: git
     location: https://github.com/pdobsan/githash
+    tag: d006ec12c4a241b825fc76bd6baec549ff23d4fe


### PR DESCRIPTION
This pins the Cabal `source-repository-package` for `pdobsan/githash` (githash fork) to commit `d006ec1` to make builds reproducible and avoid accidental upstream changes.