### PR TITLE
Add support for multiple services using same email

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -12,9 +12,9 @@ main = do
   withSyslog "oama" [] Mail $ do
     env <- loadEnvironment
     case optCommand $ options env of
-      Oauth2 emailAddress -> getEmailAuth env (EmailAddress emailAddress)
-      ShowCreds emailAddress -> showCreds env (EmailAddress emailAddress)
-      Renew emailAddress -> forceRenew env (EmailAddress emailAddress)
+      Oauth2 serv emailAddress -> getEmailAuth env (EmailAddress emailAddress) serv
+      ShowCreds serv emailAddress -> showCreds env (EmailAddress emailAddress) serv
+      Renew serv emailAddress -> forceRenew env (EmailAddress emailAddress) serv
       Authorize servName emailAddress nohint device -> authorizeEmail env servName (EmailAddress emailAddress) nohint device
       PrintEnv -> pprintEnv env
       PrintTemplate -> printTemplate

--- a/configs/default-config.yaml
+++ b/configs/default-config.yaml
@@ -1,0 +1,68 @@
+## oama-config version 0.22
+##
+## This is a YAML configuration file, indentation matters.
+## Double ## indicates comments while single # default values.
+## Not all defaults are shown, for full list run `oama printenv`
+## and look at the `services:` section.
+##
+## Possible options for keeping refresh and access tokens:
+## GPG - in a gpg encrypted file $XDG_STATE_HOME/oama/<email-address>.oauth
+##       (XDG_STATE_HOME defaults to ~/.local/state)
+## GPG - in a gpg encrypted file ~/.local/state/oama/<email-address>.oauth
+## KEYRING - in the keyring of a password manager with Secret Service API
+##
+## Choose exactly one.
+
+encryption:
+    tag: KEYRING
+
+# encryption:
+#   tag: GPG
+#   contents: your-KEY-ID
+
+## Builtin service providers
+## - google
+## - microsoft
+## Required fields: client_id, client_secret
+##
+services:
+  google:
+    client_id: application-CLIENT-ID
+    client_secret: application-CLIENT-SECRET
+  ## Alternatively get them from a password manager using a shell command.
+  ## If both variants are present then the _cmd versions get the priority.
+  ## For example:
+  # client_id_cmd: |
+  #   pass email/my-app | head -1
+  # client_secret_cmd: |
+  #   pass email/my-app | head -2 | tail -1
+  #  auth_scope: https://mail.google.com/
+
+  microsoft:
+     client_id: application-CLIENT-ID
+  ## client_secret is not needed for device code flow
+  #  auth_endpoint: https://login.microsoftonline.com/common/oauth2/v2.0/devicecode
+  ##
+  ## client_secret might be needed for other authorization flows
+  #  client_secret: application-CLIENT_SECRET
+  ## auth_endpoint: https://login.microsoftonline.com/common/oauth2/v2.0/authorize
+  #
+  #  auth_scope: https://outlook.office.com/IMAP.AccessAsUser.All
+  #     https://outlook.office.com/SMTP.Send
+  #     offline_access
+  #  tenant: common
+
+  ## User configured providers
+  ## Required fields: client_id, client_secret, auth_endpoint, auth_scope, token_endpoint
+  ##
+  ## For example:
+  # yahoo:
+  #   client_id: application-CLIENT-ID
+  #   client_id_cmd: |
+  #     password manager command ...
+  #   client_secret: application-CLIENT_SECRET
+  #   client_secret_cmd: |
+  #     password manager command ...
+  #   auth_endpoint: EDIT-ME!
+  #   auth_scope: EDIT-ME!
+  #   token_endpoint: EDIT-ME!

--- a/lib/OAMa/Authorization.hs
+++ b/lib/OAMa/Authorization.hs
@@ -54,13 +54,17 @@ import Web.Twain qualified as TW
 --
 -- The managed credentials are kept in either in a libsecret based keyring (like Gnome's)
 -- or in GPG encrypted files. Only one of these methods can be used.
+--
+-- Multiple services can be stored for the same email address:
+-- - KEYRING: stored with attribute "oama:service"="email".
+-- - GPG: stored in file "email.service.oama".
 
-getAuthRecord :: Environment -> EmailAddress -> IO AuthRecord
-getAuthRecord env email_ = do
+getAuthRecord :: Environment -> EmailAddress -> String -> IO AuthRecord
+getAuthRecord env email_ serv = do
   getAR env.config.encryption
  where
   getAR KEYRING = do
-    lookupSecret "oama" email_.unEmailAddress
+    lookupSecret ("oama" <> ":" <> serv) email_.unEmailAddress
       >>= \case
         Right o ->
           case eitherDecode' (BLU.fromString o) :: Either String AuthRecord of
@@ -68,7 +72,7 @@ getAuthRecord env email_ = do
             Right rec -> return rec
         Left e -> fatalError "getAuthRecord" (show e)
   getAR (GPG _) = do
-    let gpgFile = env.state_dir <> "/" <> email_.unEmailAddress <> ".oama"
+    let gpgFile = env.state_dir <> "/" <> email_.unEmailAddress <> "." <> serv <> ".oama"
     authRecExist <- D.doesFileExist gpgFile
     if authRecExist
       then do
@@ -82,17 +86,20 @@ getAuthRecord env email_ = do
       else do
         printf "You must run `oama authorize ...` before using other operations.\n"
         fatalError "getAuthRecord" $
-          printf "Can't find authorization record for %s\n" (unEmailAddress email_)
+          printf "Can't find authorization record for %s with service %s\n" (unEmailAddress email_) serv
 
-putAuthRecord :: Environment -> EmailAddress -> AuthRecord -> IO ()
-putAuthRecord env email_ rec = do
+putAuthRecord :: Environment -> EmailAddress -> String -> AuthRecord -> IO ()
+putAuthRecord env email_ serv rec = do
   let jsrec = BLU.toString $ encode rec
-      m = email_.unEmailAddress
-      gpgFile = env.state_dir <> "/" <> email_.unEmailAddress <> ".oama"
+      addr = email_.unEmailAddress
+      keyring_attrib_key = "oama" <> ":" <> serv
+      keyring_label = "oama - " <> serv <> " - " <> addr
+      gpgFile = env.state_dir <> "/" <> addr <> "." <> serv <> ".oama"
+
       putAR :: Encryption -> IO ()
       putAR KEYRING =
         do
-          storeSecret ("oama - " ++ m) "oama" m jsrec
+          storeSecret keyring_label keyring_attrib_key addr jsrec
           >>= \case
             Right _ -> return ()
             Left e -> do
@@ -114,16 +121,16 @@ timeStampFormat = "%Y-%m-%d %H:%M %Z"
 
 -- | Get access_token for then given email
 -- while renewing it when necessary
-getEmailAuth :: Environment -> EmailAddress -> IO ()
-getEmailAuth env email_ = do
-  getEmailAuth' env email_
+getEmailAuth :: Environment -> EmailAddress -> String -> IO ()
+getEmailAuth env email_ serv = do
+  getEmailAuth' env email_ serv
     >>= \case
       Right rec -> putStrLn $ access_token rec
       Left errmsg -> fatalError "getEmailAuth" $ printf "getEmailAuth: %s" (show errmsg)
 
-getEmailAuth' :: Environment -> EmailAddress -> IO (Either AuthError AuthRecord)
-getEmailAuth' env email_ = do
-  authrec <- getAuthRecord env email_
+getEmailAuth' :: Environment -> EmailAddress -> String -> IO (Either AuthError AuthRecord)
+getEmailAuth' env email_ serv = do
+  authrec <- getAuthRecord env email_ serv
   now <- getCurrentTime
   let expd = fromMaybe "2000-01-01 12:00 UTC" authrec.exp_date
   if now > parseTimeOrError True defaultTimeLocale timeStampFormat expd
@@ -144,8 +151,8 @@ getEmailAuth' env email_ = do
                       scope = newat.scope,
                       token_type = newat.token_type
                     }
-            putAuthRecord env email_ authrec'
-            logger Notice $ printf "new access token for %s - expires at %s" (unEmailAddress email_) expDate
+            putAuthRecord env email_ serv authrec'
+            logger Notice $ printf "new access token for %s (service: %s) - expires at %s" (unEmailAddress email_) serv expDate
             return $ Right authrec'
     else return $ Right authrec
 
@@ -242,9 +249,9 @@ renewAccessToken env (Just serv) rft = do
     (fromJust api.token_endpoint)
     qs
 
-forceRenew :: Environment -> EmailAddress -> IO ()
-forceRenew env email_ = do
-  authrec <- getAuthRecord env email_
+forceRenew :: Environment -> EmailAddress -> String -> IO ()
+forceRenew env email_ serv = do
+  authrec <- getAuthRecord env email_ serv
   now <- getCurrentTime
   renewAccessToken env (service authrec) (refresh_token authrec)
     >>= \case
@@ -262,14 +269,14 @@ forceRenew env email_ = do
                   scope = scope newat,
                   token_type = token_type newat
                 }
-        putAuthRecord env email_ authrec'
-        logger Notice $ printf "new access token for %s - expires at %s" (unEmailAddress email_) expDate
-        printf "Obtained new access token for %s - expires at %s.\n" (unEmailAddress email_) expDate
+        putAuthRecord env email_ serv authrec'
+        logger Notice $ printf "new access token for %s (service: %s) - expires at %s" (unEmailAddress email_) serv expDate
+        printf "Obtained new access token for %s (service: %s) - expires at %s.\n" (unEmailAddress email_) serv expDate
 
 -- | Show current credentials for the given email
-showCreds :: Environment -> EmailAddress -> IO ()
-showCreds env email_ = do
-  getEmailAuth' env email_
+showCreds :: Environment -> EmailAddress -> String -> IO ()
+showCreds env email_ serv = do
+  getEmailAuth' env email_ serv
     >>= \case
       Right rec -> do
         printf "email: %s\n" (unEmailAddress $ fromJust rec.email)
@@ -395,14 +402,14 @@ storeAuthRecord env servName email_ authr = do
   let expire = addUTCTime (expires_in authr - 300) now
       expDate = formatTime defaultTimeLocale timeStampFormat expire
       authRec = authr{exp_date = Just expDate, email = Just email_, service = Just servName}
-  putAuthRecord env email_ authRec
+  putAuthRecord env email_ servName authRec
   printf "Received refresh and access tokens ...\n"
   if env.config.encryption == KEYRING
     then printf "They have been stored in the keyring of your password manager. ...\n"
     else
       printf
         "They have been saved in %s encrypted ...\n"
-        (env.state_dir <> "/" <> email_.unEmailAddress <> ".oama")
+        (env.state_dir <> "/" <> email_.unEmailAddress <> "." <> servName <> ".oama")
 
 data AuthResult = AuthSuccess | AuthFailure
 
@@ -445,13 +452,13 @@ localWebServer mvar env redirectURI serv email_ noHint = do
                         TW.send $
                           TW.html $
                             BLU.fromString $
-                              printf "<h4>Received new refresh and access tokens for %s</h4>" (unEmailAddress email_)
+                              printf "<h4>Received new refresh and access tokens for %s (service: %s)</h4>" (unEmailAddress email_) serv
                                 <> if env.config.encryption == KEYRING
                                   then printf "<p>They have been stored in the keyring of your password manager.</p>"
                                   else
                                     printf
                                       "<p>They have been saved in <samp>%s</samp> encrypted.</p>"
-                                      (env.state_dir <> "/" <> email_.unEmailAddress <> ".oama")
+                                      (env.state_dir <> "/" <> email_.unEmailAddress <> "." <> serv <> ".oama")
                 else liftIO $ fatalError "localWebServer" (printf "states don't match: %s /= %s" state state')
 
             casService :: TW.ResponderM a

--- a/lib/OAMa/CommandLine.hs
+++ b/lib/OAMa/CommandLine.hs
@@ -42,10 +42,11 @@ data Opts = Opts
   }
   deriving (Show, Generic, Yaml.ToJSON, Yaml.FromJSON)
 
+-- Command now carries service + email for the commands that operate on a service
 data Command
-  = Oauth2 String
-  | ShowCreds String
-  | Renew String
+  = Oauth2 String String        -- service, email
+  | ShowCreds String String     -- service, email
+  | Renew String String         -- service, email
   | Authorize String String Bool Bool
   | PrintEnv
   | PrintTemplate
@@ -89,19 +90,25 @@ programOptions =
     <*> hsubparser (oauth2 <> showcreds <> renew <> authorize <> printEnv <> printTemplate)
 
 oauth2 :: Mod CommandFields Command
-oauth2 = command "access" (info oauth2Options (progDesc "Get the access token for email"))
+oauth2 = command "access" (info oauth2Options (progDesc "Get the access token for a (service, email) pair."))
 oauth2Options :: Parser Command
-oauth2Options = Oauth2 <$> strArgument (metavar "<email>" <> help "Email address")
+oauth2Options = Oauth2
+  <$> strArgument (metavar "<service>" <> help "Service name")
+  <*> strArgument (metavar "<email>" <> help "Email address")
 
 showcreds :: Mod CommandFields Command
-showcreds = command "show" (info showcredsOptions (progDesc "Show current credentials for email"))
+showcreds = command "show" (info showcredsOptions (progDesc "Show current credentials for a (service, email) pair."))
 showcredsOptions :: Parser Command
-showcredsOptions = ShowCreds <$> strArgument (metavar "<email>" <> help "Email address")
+showcredsOptions = ShowCreds
+  <$> strArgument (metavar "<service>" <> help "Service name")
+  <*> strArgument (metavar "<email>" <> help "Email address")
 
 renew :: Mod CommandFields Command
-renew = command "renew" (info renewOptions (progDesc "Renew the access token of email"))
+renew = command "renew" (info renewOptions (progDesc "Renew the access token for a (service, email) pair."))
 renewOptions :: Parser Command
-renewOptions = Renew <$> strArgument (metavar "<email>" <> help "Email address")
+renewOptions = Renew
+  <$> strArgument (metavar "<service>" <> help "Service name")
+  <*> strArgument (metavar "<email>" <> help "Email address")
 
 authorize :: Mod CommandFields Command
 authorize = command "authorize" (info authorizeOptions (progDesc "Authorize OAuth2 for service/email"))

--- a/lib/OAMa/Environment.hs
+++ b/lib/OAMa/Environment.hs
@@ -3,9 +3,9 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE MultilineStrings #-}
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module OAMa.Environment (
   AuthRecord (..),
@@ -38,6 +38,7 @@ import Data.Aeson.Types (
  )
 import Data.ByteString.UTF8 qualified as BSU
 import Data.Char (isSpace)
+import Data.FileEmbed (embedStringFile)
 import Data.Map (Map)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromJust)
@@ -393,76 +394,4 @@ printTemplate :: IO ()
 printTemplate = putStr initialConfig
 
 initialConfig :: String
-initialConfig =
-  "## oama version "
-    <> versionInfo
-    <> """
-
-       ## This is a YAML configuration file, indentation matters.
-       ## Double ## indicates comments while single # default values.
-       ## Not all defaults are shown, for full list run `oama printenv`
-       ## and look at the `services:` section.
-
-       ## Possible options for keeping refresh and access tokens:
-       ## GPG - in a gpg encrypted file $XDG_STATE_HOME/oama/<email-address>.oauth
-       ##       (XDG_STATE_HOME defaults to ~/.local/state)
-       ## GPG - in a gpg encrypted file ~/.local/state/oama/<email-address>.oauth
-       ## KEYRING - in the keyring of a password manager with Secret Service API
-       ##
-       ## Choose exactly one.
-
-       encryption:
-           tag: KEYRING
-
-       # encryption:
-       #   tag: GPG
-       #   contents: your-KEY-ID
-
-       ## Builtin service providers
-       ## - google
-       ## - microsoft
-       ## Required fields: client_id, client_secret
-       ##
-       services:
-         google:
-           client_id: application-CLIENT-ID
-           client_secret: application-CLIENT-SECRET
-         ## Alternatively get them from a password manager using a shell command.
-         ## If both variants are present then the _cmd versions get the priority.
-         ## For example:
-         # client_id_cmd: |
-         #   pass email/my-app | head -1
-         # client_secret_cmd: |
-         #   pass email/my-app | head -2 | tail -1
-         #  auth_scope: https://mail.google.com/
-
-         microsoft:
-            client_id: application-CLIENT-ID
-         ## client_secret is not needed for device code flow
-         #  auth_endpoint: https://login.microsoftonline.com/common/oauth2/v2.0/devicecode
-         ##
-         ## client_secret might be needed for other authorization flows
-         #  client_secret: application-CLIENT_SECRET
-         ## auth_endpoint: https://login.microsoftonline.com/common/oauth2/v2.0/authorize
-         #
-         #  auth_scope: https://outlook.office.com/IMAP.AccessAsUser.All
-         #     https://outlook.office.com/SMTP.Send
-         #     offline_access
-         #  tenant: common
-
-         ## User configured providers
-         ## Required fields: client_id, client_secret, auth_endpoint, auth_scope, token_endpoint
-         ##
-         ## For example:
-         # yahoo:
-         #   client_id: application-CLIENT-ID
-         #   client_id_cmd: |
-         #     password manager command ...
-         #   client_secret: application-CLIENT_SECRET
-         #   client_secret_cmd: |
-         #     password manager command ...
-         #   auth_endpoint: EDIT-ME!
-         #   auth_scope: EDIT-ME!
-         #   token_endpoint: EDIT-ME!
-
-       """
+initialConfig = $(embedStringFile "configs/default-config.yaml")

--- a/oama.cabal
+++ b/oama.cabal
@@ -1,4 +1,4 @@
-cabal-version:      3.14
+cabal-version:      3.8
 name:               oama
 version:            0.22.0
 license:            BSD-3-Clause

--- a/oama.cabal
+++ b/oama.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.8
 name:               oama
-version:            0.22.0
+version:            0.23.0
 license:            BSD-3-Clause
 license-file:       LICENSE
 author:             Peter Dobsan

--- a/oama.cabal
+++ b/oama.cabal
@@ -7,6 +7,7 @@ author:             Peter Dobsan
 maintainer:         pdobsan@gmail.com
 extra-source-files:
 data-files:
+  configs/default-config.yaml
 
 flag lib-gpgme
   description: Use the gpgme API-s
@@ -49,6 +50,7 @@ common common
     utf8-string,
     warp,
     yaml,
+    file-embed,
   if flag(lib-gpgme)
     cpp-options: -DLIB_GPGME
     build-depends:


### PR DESCRIPTION
We add storage name in the identifier so that we can differentiate between services on access.

While at it, fix the build for normal systems.